### PR TITLE
Update the gl-dept deployment

### DIFF
--- a/kubernetes/deployments/gl-dept-deployment.yaml
+++ b/kubernetes/deployments/gl-dept-deployment.yaml
@@ -27,7 +27,7 @@ spec:
             configMapKeyRef:
               key: dept-mongouri
               name: gl-config
-        image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-dept:6eb6063d2dd65a622234470ff89c277e22f0ea3e
+        image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-dept:v0.0.1
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5


### PR DESCRIPTION
This commit updates the gl-dept deployment container image to:

    gcr.io/oceanic-isotope-199421/github-zmad5306-gl-dept:v0.0.1

Build ID: 8b24dce0-25b8-4ef7-9104-ddbda08979cf