### PR TITLE
Update the gl-item deployment

### DIFF
--- a/kubernetes/deployments/gl-item-deployment.yaml
+++ b/kubernetes/deployments/gl-item-deployment.yaml
@@ -27,7 +27,7 @@ spec:
             configMapKeyRef:
               key: item-mongouri
               name: gl-config
-        image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-item:5b9c6bb3b92ce5c567f806f78eb74b7f7a5eb2fb
+        image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-item:0.0.1
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5


### PR DESCRIPTION
This commit updates the gl-item deployment container image to:

    gcr.io/oceanic-isotope-199421/github-zmad5306-gl-item:0.0.1

Build ID: 576c75fe-5b3e-4b80-8e20-8f577e1c4c35