### PR TITLE
Update the gl-api deployment

### DIFF
--- a/kubernetes/deployments/gl-api-deployment.yaml
+++ b/kubernetes/deployments/gl-api-deployment.yaml
@@ -27,7 +27,7 @@ spec:
             configMapKeyRef:
               key: api-mongouri
               name: gl-config
-        image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-api:50c151ff3f501c24b5e4b1d7a05953f9ef2f8e8b
+        image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-api:0.0.1
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5


### PR DESCRIPTION
This commit updates the gl-api deployment container image to:

    gcr.io/oceanic-isotope-199421/github-zmad5306-gl-api:0.0.1

Build ID: e9a4e14e-bf07-4c8e-976f-4dae57a27e59