### PR TITLE
Update the gl-list deployment

### DIFF
--- a/kubernetes/deployments/gl-list-deployment.yaml
+++ b/kubernetes/deployments/gl-list-deployment.yaml
@@ -27,7 +27,7 @@ spec:
             configMapKeyRef:
               key: list-mongouri
               name: gl-config
-        image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-list:aa602dbfd5984d2076a6bfbcf7a1dd422d2579ab
+        image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-list:0.0.1
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5


### PR DESCRIPTION
This commit updates the gl-list deployment container image to:

    gcr.io/oceanic-isotope-199421/github-zmad5306-gl-list:0.0.1

Build ID: 036a8538-e1da-463d-b6fe-d8652115b66f