### PR TITLE
Update the gl-ui deployment

### DIFF
--- a/kubernetes/deployments/gl-ui-deployment.yaml
+++ b/kubernetes/deployments/gl-ui-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         app: gl-ui
     spec:
       containers:
-      - image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-ui:9dc6472d4728377214996d20d82e81bd11b71b5c
+      - image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-ui:0.0.1
         name: gl-ui
         ports:
         - containerPort: 80


### PR DESCRIPTION
This commit updates the gl-ui deployment container image to:

    gcr.io/oceanic-isotope-199421/github-zmad5306-gl-ui:0.0.1

Build ID: d34f44e1-ffd2-4ab8-8ffd-55b6446f3f7f