### PR TITLE
Update the gl-api deployment

### DIFF
--- a/kubernetes/deployments/gl-api-deployment.yaml
+++ b/kubernetes/deployments/gl-api-deployment.yaml
@@ -27,7 +27,7 @@ spec:
             configMapKeyRef:
               key: api-mongouri
               name: gl-config
-        image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-api:50c151ff3f501c24b5e4b1d7a05953f9ef2f8e8b
+        image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-api:v0.0.1
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5


### PR DESCRIPTION
This commit updates the gl-api deployment container image to:

    gcr.io/oceanic-isotope-199421/github-zmad5306-gl-api:v0.0.1

Build ID: 4d0a656d-2fee-462d-8967-a473ce083d03