### PR TITLE
Update the gl-item deployment

### DIFF
--- a/kubernetes/deployments/gl-item-deployment.yaml
+++ b/kubernetes/deployments/gl-item-deployment.yaml
@@ -27,7 +27,7 @@ spec:
             configMapKeyRef:
               key: item-mongouri
               name: gl-config
-        image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-item:5b9c6bb3b92ce5c567f806f78eb74b7f7a5eb2fb
+        image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-item:v0.0.1
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5


### PR DESCRIPTION
This commit updates the gl-item deployment container image to:

    gcr.io/oceanic-isotope-199421/github-zmad5306-gl-item:v0.0.1

Build ID: 40d5daac-2931-41e2-87d0-d5de0826b5a1