### PR TITLE
Update the gl-dept deployment

### DIFF
--- a/kubernetes/deployments/gl-dept-deployment.yaml
+++ b/kubernetes/deployments/gl-dept-deployment.yaml
@@ -27,7 +27,7 @@ spec:
             configMapKeyRef:
               key: dept-mongouri
               name: gl-config
-        image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-dept:v0.0.1
+        image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-dept:v0.0.2.1
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5


### PR DESCRIPTION
This commit updates the gl-dept deployment container image to:

    gcr.io/oceanic-isotope-199421/github-zmad5306-gl-dept:v0.0.2.1

Build ID: 2a60235f-6fc2-4060-bd04-2f66cd75a83b