### PR TITLE
Update the gl-list deployment

### DIFF
--- a/kubernetes/deployments/gl-list-deployment.yaml
+++ b/kubernetes/deployments/gl-list-deployment.yaml
@@ -27,7 +27,7 @@ spec:
             configMapKeyRef:
               key: list-mongouri
               name: gl-config
-        image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-list:v0.0.1
+        image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-list:v0.0.2.1
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5


### PR DESCRIPTION
This commit updates the gl-list deployment container image to:

    gcr.io/oceanic-isotope-199421/github-zmad5306-gl-list:v0.0.2.1

Build ID: 0b577e82-bfc4-4f58-b3de-ec75bd49a0d2