### PR TITLE
Update the gl-api deployment

### DIFF
--- a/kubernetes/deployments/gl-api-deployment.yaml
+++ b/kubernetes/deployments/gl-api-deployment.yaml
@@ -27,7 +27,7 @@ spec:
             configMapKeyRef:
               key: api-mongouri
               name: gl-config
-        image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-api:v0.0.1
+        image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-api:v0.0.2.1
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5


### PR DESCRIPTION
This commit updates the gl-api deployment container image to:

    gcr.io/oceanic-isotope-199421/github-zmad5306-gl-api:v0.0.2.1

Build ID: 5560a538-ad58-4693-aafc-90ddf95ecf86