### PR TITLE
Update the gl-item deployment

### DIFF
--- a/kubernetes/deployments/gl-item-deployment.yaml
+++ b/kubernetes/deployments/gl-item-deployment.yaml
@@ -27,7 +27,7 @@ spec:
             configMapKeyRef:
               key: item-mongouri
               name: gl-config
-        image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-item:v0.0.1
+        image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-item:v0.0.2.1
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5


### PR DESCRIPTION
This commit updates the gl-item deployment container image to:

    gcr.io/oceanic-isotope-199421/github-zmad5306-gl-item:v0.0.2.1

Build ID: 45e526a5-f23d-49c6-9585-c8e5942e81df