### PR TITLE
Update the gl-dept deployment

### DIFF
--- a/kubernetes/deployments/gl-dept-deployment.yaml
+++ b/kubernetes/deployments/gl-dept-deployment.yaml
@@ -27,7 +27,7 @@ spec:
             configMapKeyRef:
               key: dept-mongouri
               name: gl-config
-        image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-dept:v0.0.3.1
+        image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-dept:v0.0.3.2
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5


### PR DESCRIPTION
This commit updates the gl-dept deployment container image to:

    gcr.io/oceanic-isotope-199421/github-zmad5306-gl-dept:v0.0.3.2

Build ID: b3082ad3-e522-4cd6-bd90-0a2d34915ec5