### PR TITLE
Update the gl-ui deployment

### DIFF
--- a/kubernetes/deployments/gl-ui-deployment.yaml
+++ b/kubernetes/deployments/gl-ui-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         app: gl-ui
     spec:
       containers:
-      - image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-ui:v0.0.2.1
+      - image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-ui:v0.0.2.2
         name: gl-ui
         ports:
         - containerPort: 80


### PR DESCRIPTION
This commit updates the gl-ui deployment container image to:

    gcr.io/oceanic-isotope-199421/github-zmad5306-gl-ui:v0.0.2.2

Build ID: 499009a2-9e7d-4ae7-bc70-48eaf81738cd