### PR TITLE
Update the gl-dept deployment

### DIFF
--- a/kubernetes/deployments/gl-dept-deployment.yaml
+++ b/kubernetes/deployments/gl-dept-deployment.yaml
@@ -27,7 +27,6 @@ spec:
             configMapKeyRef:
               key: dept-mongouri
               name: gl-config
-        image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-dept:v0.0.3.3
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5


### PR DESCRIPTION
This commit updates the gl-dept deployment container image to:

    

Build ID: 84023273-0d4b-41ee-8bd1-abf129c311ec