### PR TITLE
Update the gl-item deployment

### DIFF
--- a/kubernetes/deployments/gl-item-deployment.yaml
+++ b/kubernetes/deployments/gl-item-deployment.yaml
@@ -27,7 +27,7 @@ spec:
             configMapKeyRef:
               key: item-mongouri
               name: gl-config
-        image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-item:v0.0.2.2
+        image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-item:v0.0.2.4
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5


### PR DESCRIPTION
This commit updates the gl-item deployment container image to:

    

Build ID: 329d0326-1fba-4080-8b4b-676dbb33e28a