### PR TITLE
Update the gl-ui deployment

### DIFF
--- a/kubernetes/deployments/gl-ui-deployment.yaml
+++ b/kubernetes/deployments/gl-ui-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         app: gl-ui
     spec:
       containers:
-      - image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-ui:v0.0.2.2
+      - image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-ui:v0.0.2.5
         name: gl-ui
         ports:
         - containerPort: 80


### PR DESCRIPTION
This commit updates the gl-ui deployment container image to:

    

Build ID: a244d1d3-4006-4639-a243-cfcf6aff1d9d