### PR TITLE
Update the gl-api deployment

### DIFF
--- a/kubernetes/deployments/gl-api-deployment.yaml
+++ b/kubernetes/deployments/gl-api-deployment.yaml
@@ -27,7 +27,7 @@ spec:
             configMapKeyRef:
               key: api-mongouri
               name: gl-config
-        image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-api:v0.0.2.4
+        image: gcr.io/grocery-list-205220/github-zmad5306-gl-api:v0.0.2.5
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5


### PR DESCRIPTION
This commit updates the gl-api deployment container image to:

    

Build ID: 45f35f84-db4e-451c-8472-b29ccc4338f6