### PR TITLE
Update the gl-item deployment

### DIFF
--- a/kubernetes/deployments/gl-item-deployment.yaml
+++ b/kubernetes/deployments/gl-item-deployment.yaml
@@ -27,7 +27,7 @@ spec:
             configMapKeyRef:
               key: item-mongouri
               name: gl-config
-        image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-item:v0.0.2.5
+        image: gcr.io/grocery-list-205220/github-zmad5306-gl-item:v0.0.2.6
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5


### PR DESCRIPTION
This commit updates the gl-item deployment container image to:

    

Build ID: 1b4d82ed-99c4-4401-8676-a9f162e5f03f