### PR TITLE
Update the gl-dept deployment

### DIFF
--- a/kubernetes/deployments/gl-dept-deployment.yaml
+++ b/kubernetes/deployments/gl-dept-deployment.yaml
@@ -27,7 +27,7 @@ spec:
             configMapKeyRef:
               key: dept-mongouri
               name: gl-config
-        image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-dept:v0.0.3.6
+        image: gcr.io/grocery-list-205220/github-zmad5306-gl-dept:v0.0.3.7
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5


### PR DESCRIPTION
This commit updates the gl-dept deployment container image to:

    

Build ID: bd3f2c18-8751-4afc-85b4-c9a41e851113