### PR TITLE
Update the gl-list deployment

### DIFF
--- a/kubernetes/deployments/gl-list-deployment.yaml
+++ b/kubernetes/deployments/gl-list-deployment.yaml
@@ -27,7 +27,7 @@ spec:
             configMapKeyRef:
               key: list-mongouri
               name: gl-config
-        image: gcr.io/oceanic-isotope-199421/github-zmad5306-gl-list:v0.0.2.5
+        image: gcr.io/grocery-list-205220/github-zmad5306-gl-list:v0.0.2.6
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5


### PR DESCRIPTION
This commit updates the gl-list deployment container image to:

    

Build ID: cf5a7005-f603-4841-b5fa-54675c3854ad