### PR TITLE
Update the gl-ui deployment

### DIFF
--- a/kubernetes/deployments/gl-ui-deployment.yaml
+++ b/kubernetes/deployments/gl-ui-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         app: gl-ui
     spec:
       containers:
-      - image: gcr.io/grocery-list-205220/github-zmad5306-gl-ui:v0.0.3.1
+      - image: gcr.io/grocery-list-205220/github-zmad5306-gl-ui:v0.0.3.2
         name: gl-ui
         ports:
         - containerPort: 80


### PR DESCRIPTION
This commit updates the gl-ui deployment container image to:

    

Build ID: 0e156300-9b49-4b5c-81e3-3f26f210c7e5