### PR TITLE
Update the gl-ui deployment

### DIFF
--- a/kubernetes/deployments/gl-ui-deployment.yaml
+++ b/kubernetes/deployments/gl-ui-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         app: gl-ui
     spec:
       containers:
-      - image: gcr.io/grocery-list-205220/github-zmad5306-gl-ui:v0.0.3.2
+      - image: gcr.io/grocery-list-205220/github-zmad5306-gl-ui:v4.0.0
         name: gl-ui
         ports:
         - containerPort: 80


### PR DESCRIPTION
This commit updates the gl-ui deployment container image to:

    

Build ID: 6a0d1d06-0e3e-4f84-ae4b-f4c9e5b8d466